### PR TITLE
Fix a bug in the unification

### DIFF
--- a/Llk/Parser.php
+++ b/Llk/Parser.php
@@ -289,7 +289,8 @@ class Parser {
                             --$skip;
                         }
                     }
-                    elseif($trace instanceof Rule\Ekzit)
+                    elseif(   $trace instanceof Rule\Ekzit
+                           && false === $trace->isTransitional())
                         $skip += $trace->getDepth() > $this->_depth;
 
                     if(0 < $skip)


### PR DESCRIPTION
The `skip` counter, introduced as an optmization to avoid unnecessary assertions, was decremented correctly but not incremented/restored well. This patch fix this bug.
