### PR TITLE
Add offset support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /composer.lock
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /vendor/
 /composer.lock
-/.idea

--- a/Llk/Parser.php
+++ b/Llk/Parser.php
@@ -325,8 +325,11 @@ class Parser
             }
 
             $namespace = $this->_tokenSequence->current()['namespace'];
+            $offset = $this->_tokenSequence->current()['offset'];
+
             $zzeRule   = clone $zeRule;
             $zzeRule->setValue($value);
+            $zzeRule->setOffset($offset);
             $zzeRule->setNamespace($namespace);
 
             if (isset($this->_tokens[$namespace][$name])) {
@@ -595,7 +598,9 @@ class Parser
                     'token'     => $trace->getTokenName(),
                     'value'     => $trace->getValue(),
                     'namespace' => $trace->getNamespace(),
+                    'offset'    => $trace->getOffset()
                 ]);
+
                 $children[] = $child;
                 ++$i;
             }

--- a/Llk/Parser.php
+++ b/Llk/Parser.php
@@ -324,8 +324,10 @@ class Parser
                 }
             }
 
-            $namespace = $this->_tokenSequence->current()['namespace'];
-            $offset = $this->_tokenSequence->current()['offset'];
+            $current = $this->_tokenSequence->current();
+
+            $namespace = $current['namespace'];
+            $offset = $current['offset'];
 
             $zzeRule   = clone $zeRule;
             $zzeRule->setValue($value);

--- a/Llk/Rule/Token.php
+++ b/Llk/Rule/Token.php
@@ -105,7 +105,12 @@ class Token extends Rule
      */
     protected $_unification          = -1;
 
-
+    /**
+     * Token offset.
+     *
+     * @var int
+     */
+    protected $_offset               = 0;
 
     /**
      * Constructor.
@@ -235,6 +240,27 @@ class Token extends Rule
     public function getValue()
     {
         return $this->_value;
+    }
+
+    /**
+     * Set token offset.
+     *
+     * @param int $offset
+     * @return void
+     */
+    public function setOffset($offset)
+    {
+        $this->_offset = $offset;
+    }
+
+    /**
+     * Get token offset.
+     *
+     * @return int
+     */
+    public function getOffset()
+    {
+        return $this->_offset;
     }
 
     /**

--- a/Llk/TreeNode.php
+++ b/Llk/TreeNode.php
@@ -176,6 +176,19 @@ class TreeNode implements Visitor\Element
     }
 
     /**
+     * Get token offset.
+     *
+     * @return int
+     */
+    public function getOffset()
+    {
+        return
+            isset($this->_value['offset'])
+                ? $this->_value['offset']
+                : 0;
+    }
+
+    /**
      * Get value value.
      *
      * @return  string

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 ---
 
 <p align="center">
-  <a href="https://travis-ci.org/hoaproject/compiler"><img src="https://img.shields.io/travis/hoaproject/compiler/master.svg" alt="Build status" /></a>
-  <a href="https://coveralls.io/github/hoaproject/compiler?branch=master"><img src="https://img.shields.io/coveralls/hoaproject/compiler/master.svg" alt="Code coverage" /></a>
+  <a href="https://travis-ci.org/hoaproject/Compiler"><img src="https://img.shields.io/travis/hoaproject/Compiler/master.svg" alt="Build status" /></a>
+  <a href="https://coveralls.io/github/hoaproject/Compiler?branch=master"><img src="https://img.shields.io/coveralls/hoaproject/Compiler/master.svg" alt="Code coverage" /></a>
   <a href="https://packagist.org/packages/hoa/compiler"><img src="https://img.shields.io/packagist/dt/hoa/compiler.svg" alt="Packagist" /></a>
   <a href="https://hoa-project.net/LICENSE"><img src="https://img.shields.io/packagist/l/hoa/compiler.svg" alt="License" /></a>
 </p>


### PR DESCRIPTION
Edit by @Hywan: Fix #70.

In addition to synax analysis (lex), there is also a semantic analysis of code. And in the case of errors of semantics, it is required to understand exactly where the error occurred. Like:

```php
function a(int $b) {}
a(null);

// Error: Integer required in XXX file on line 2 and offset 3, but null given.
// a(null);
//   ^
```
The only way to get this information is the TreeNode instance.


This PR adds TreeNode::getOffset() method support for tokens:
```php
class TreeNode {
    // Additional method
    public function getOffset(): int;
}
```