### PR TITLE
Fix the incorrect display of the column and line in errors.

### DIFF
--- a/Exception/ExceptionHelper.php
+++ b/Exception/ExceptionHelper.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2017, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Compiler\Exception;
+
+/**
+ * Class \Hoa\Compiler\Exception.
+ *
+ * Extending the \Hoa\Exception\Exception class.
+ *
+ * @copyright  Copyright © 2007-2017 Hoa community
+ * @license    New BSD License
+ */
+trait ExceptionHelper
+{
+    /**
+     * This is an auxiliary method that returns the line number, shift,
+     * and line of code by shift relative to the beginning of the file.
+     *
+     * @param   string $text        The source code
+     * @param   int    $bytesOffset Offset in bytes
+     * @return  array
+     */
+    protected function getErrorPositionByOffset($text, $bytesOffset)
+    {
+        $result = $this->getErrorInfo($text, $bytesOffset);
+        $code   = $this->getAffectedCodeAsString($result['trace']);
+
+        $column = $this->getMbColumnPosition($code, $result['column']);
+
+        return [
+            'line'      => $result['line'],
+            'code'      => $code,
+            'column'    => $column,
+            'highlight' => $this->getStringHighligher($column),
+        ];
+    }
+
+    /**
+     * Returns the last line with an error. If the error occurred on
+     * the line where there is no visible part, before complements
+     * it with the previous ones.
+     *
+     * @param array|string[] $textLines List of code lines
+     * @return string
+     */
+    private function getAffectedCodeAsString(array $textLines)
+    {
+        $result = '';
+        $i = 0;
+
+        while (\count($textLines) && ++$i) {
+            $textLine = \array_pop($textLines);
+            $result   = $textLine . ($i > 1 ? "\n" . $result : '');
+
+            if (\trim($textLine)) {
+                break;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * The method draws the highlight of the error place.
+     *
+     * @param  int $charsOffset Error offset in symbols
+     * @return string
+     */
+    private function getStringHighligher($charsOffset)
+    {
+        $prefix = '';
+
+        if ($charsOffset > 0) {
+            $prefix = \str_repeat(' ', $charsOffset);
+        }
+
+        return $prefix . '↑';
+    }
+
+    /**
+     * Returns the error location in UTF characters by the offset in bytes.
+     *
+     * @param  string $line        The code line from which we get a offset in the characters
+     * @param  int    $bytesOffset Length of offset in bytes
+     * @return int
+     */
+    private function getMbColumnPosition($line, $bytesOffset)
+    {
+        $slice = \substr($line, 0, $bytesOffset);
+
+        return \mb_strlen($slice, 'UTF-8');
+    }
+
+    /**
+     * Returns information about the error location: line, column and affected text lines.
+     *
+     * @param string $text        The source code in which we search for a line and a column
+     * @param int    $bytesOffset Offset in bytes relative to the beginning of the source code
+     * @return array
+     */
+    private function getErrorInfo($text, $bytesOffset)
+    {
+        $result = [
+            'line'   => 1,
+            'column' => 0,
+            'trace'  => [],
+        ];
+
+        $current = 0;
+
+        foreach (\explode("\n", $text) as $line => $code) {
+            $previous = $current;
+            $current += \strlen($code) + 1;
+            $result['trace'][] = $code;
+
+            if ($current > $bytesOffset) {
+                return [
+                    'line'   => $line + 1,
+                    'column' => $bytesOffset - $previous,
+                    'trace'  => $result['trace']
+                ];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/Exception/ExceptionHelper.php
+++ b/Exception/ExceptionHelper.php
@@ -54,18 +54,18 @@ trait ExceptionHelper
      * @param   int    $bytesOffset Offset in bytes
      * @return  array
      */
-    protected function getErrorPositionByOffset($text, $bytesOffset)
+    protected static function getErrorPositionByOffset($text, $bytesOffset)
     {
-        $result = $this->getErrorInfo($text, $bytesOffset);
-        $code   = $this->getAffectedCodeAsString($result['trace']);
+        $result = self::getErrorInfo($text, $bytesOffset);
+        $code   = self::getAffectedCodeAsString($result['trace']);
 
-        $column = $this->getMbColumnPosition($code, $result['column']);
+        $column = self::getMbColumnPosition($code, $result['column']);
 
         return [
             'line'      => $result['line'],
             'code'      => $code,
             'column'    => $column,
-            'highlight' => $this->getStringHighligher($column),
+            'highlight' => self::getStringHighligher($column),
         ];
     }
 
@@ -77,7 +77,7 @@ trait ExceptionHelper
      * @param array|string[] $textLines List of code lines
      * @return string
      */
-    private function getAffectedCodeAsString(array $textLines)
+    private static function getAffectedCodeAsString(array $textLines)
     {
         $result = '';
         $i = 0;
@@ -100,7 +100,7 @@ trait ExceptionHelper
      * @param  int $charsOffset Error offset in symbols
      * @return string
      */
-    private function getStringHighligher($charsOffset)
+    private static function getStringHighligher($charsOffset)
     {
         $prefix = '';
 
@@ -118,7 +118,7 @@ trait ExceptionHelper
      * @param  int    $bytesOffset Length of offset in bytes
      * @return int
      */
-    private function getMbColumnPosition($line, $bytesOffset)
+    private static function getMbColumnPosition($line, $bytesOffset)
     {
         $slice = \substr($line, 0, $bytesOffset);
 
@@ -132,7 +132,7 @@ trait ExceptionHelper
      * @param int    $bytesOffset Offset in bytes relative to the beginning of the source code
      * @return array
      */
-    private function getErrorInfo($text, $bytesOffset)
+    private static function getErrorInfo($text, $bytesOffset)
     {
         $result = [
             'line'   => 1,

--- a/Exception/UnrecognizedToken.php
+++ b/Exception/UnrecognizedToken.php
@@ -46,14 +46,14 @@ namespace Hoa\Compiler\Exception;
  */
 class UnrecognizedToken extends Exception
 {
+    use ExceptionHelper;
+
     /**
      * Column.
      *
      * @var int
      */
     protected $column = 0;
-
-
 
     /**
      * Override line and add column support.
@@ -72,6 +72,25 @@ class UnrecognizedToken extends Exception
         $this->column = $column;
 
         return;
+    }
+
+    /**
+     * @param   string  $message        Formatted message.
+     * @param   string  $text           Source code
+     * @param   int     $offsetInBytes  Error offset in bytes
+     * @param   int     $code           Code (the ID).
+     * @return  static
+     */
+    public static function fromOffset($message, $text, $offsetInBytes, $code = 0)
+    {
+        $info     = self::getErrorPositionByOffset($text, $offsetInBytes);
+
+        // Formatted message
+        $message .= ' at line %s and column %s' . \PHP_EOL .
+            $info['code'] . \PHP_EOL .
+            $info['highlight'];
+
+        return new static($message, $code, [$info['line'], $info['column']], $info['line'], $info['column']);
     }
 
     /**

--- a/Llk/Lexer.php
+++ b/Llk/Lexer.php
@@ -48,6 +48,8 @@ use Hoa\Compiler;
  */
 class Lexer
 {
+    use Compiler\Exception\ExceptionHelper;
+
     /**
      * Lexer state.
      *
@@ -82,8 +84,6 @@ class Lexer
      * @var string
      */
     protected $_pcreOptions = null;
-
-
 
     /**
      * Constructor.
@@ -147,18 +147,20 @@ class Lexer
             $nextToken = $this->nextToken($offset);
 
             if (null === $nextToken) {
+                $info = $this->getErrorPositionByOffset($text, $offset);
+
                 throw new Compiler\Exception\UnrecognizedToken(
-                    'Unrecognized token "%s" at line 1 and column %d:' .
-                    "\n" . '%s' . "\n" .
-                    str_repeat(' ', mb_strlen(substr($text, 0, $offset))) . '↑',
+                    'Unrecognized token "%s" at line %d and column %d: ' . "\n%s\n%s",
                     0,
                     [
-                        mb_substr(substr($text, $offset), 0, 1),
-                        $offset + 1,
-                        $text
+                        \mb_substr(\substr($text, $offset), 0, 1),
+                        $info['line'],
+                        $info['column'],
+                        $info['code'],
+                        $info['highlight']
                     ],
-                    1,
-                    $offset
+                    $info['line'],
+                    $info['column']
                 );
             }
 

--- a/Llk/Lexer.php
+++ b/Llk/Lexer.php
@@ -48,8 +48,6 @@ use Hoa\Compiler;
  */
 class Lexer
 {
-    use Compiler\Exception\ExceptionHelper;
-
     /**
      * Lexer state.
      *
@@ -147,21 +145,9 @@ class Lexer
             $nextToken = $this->nextToken($offset);
 
             if (null === $nextToken) {
-                $info = $this->getErrorPositionByOffset($text, $offset);
+                $error = \sprintf('Unrecognized token "%s"', \mb_substr(\substr($text, $offset), 0, 1));
 
-                throw new Compiler\Exception\UnrecognizedToken(
-                    'Unrecognized token "%s" at line %d and column %d: ' . "\n%s\n%s",
-                    0,
-                    [
-                        \mb_substr(\substr($text, $offset), 0, 1),
-                        $info['line'],
-                        $info['column'],
-                        $info['code'],
-                        $info['highlight']
-                    ],
-                    $info['line'],
-                    $info['column']
-                );
+                throw Compiler\Exception\UnrecognizedToken::fromOffset($error, $text, $offset);
             }
 
             if (true === $nextToken['keep']) {

--- a/Llk/Parser.php
+++ b/Llk/Parser.php
@@ -49,8 +49,6 @@ use Hoa\Iterator;
  */
 class Parser
 {
-    use Compiler\Exception\ExceptionHelper;
-
     /**
      * List of pragmas.
      *
@@ -188,28 +186,18 @@ class Parser
             }
 
             if (false === $this->backtrack()) {
-                $token  = $this->_errorToken;
+                $token = $this->_errorToken;
 
                 if (null === $this->_errorToken) {
                     $token = $this->_tokenSequence->current();
                 }
 
-                $info = $this->getErrorPositionByOffset($text, $token['offset']);
+                $error = \vsprintf('Unexpected token "%s" (%s)', [
+                    $token['value'],
+                    $token['token'],
+                ]);
 
-                throw new Compiler\Exception\UnexpectedToken(
-                    'Unexpected token "%s" (%s) at line %d and column %d: ' . "\n%s\n%s",
-                    0,
-                    [
-                        $token['value'],
-                        $token['token'],
-                        $info['line'],
-                        $info['column'],
-                        $info['code'],
-                        $info['highlight']
-                    ],
-                    $info['line'],
-                    $info['column']
-                );
+                throw Compiler\Exception\UnexpectedToken::fromOffset($error, $text, $token['offset']);
             }
         } while (true);
 

--- a/Llk/Parser.php
+++ b/Llk/Parser.php
@@ -49,6 +49,8 @@ use Hoa\Iterator;
  */
 class Parser
 {
+    use Compiler\Exception\ExceptionHelper;
+
     /**
      * List of pragmas.
      *
@@ -192,39 +194,21 @@ class Parser
                     $token = $this->_tokenSequence->current();
                 }
 
-                $offset = $token['offset'];
-                $line   = 1;
-                $column = 1;
-
-                if (!empty($text)) {
-                    if (0 === $offset) {
-                        $leftnl = 0;
-                    } else {
-                        $leftnl = strrpos($text, "\n", -(strlen($text) - $offset) - 1) ?: 0;
-                    }
-
-                    $rightnl = strpos($text, "\n", $offset);
-                    $line    = substr_count($text, "\n", 0, $leftnl + 1) + 1;
-                    $column  = $offset - $leftnl + (0 === $leftnl);
-
-                    if (false !== $rightnl) {
-                        $text = trim(substr($text, $leftnl, $rightnl - $leftnl), "\n");
-                    }
-                }
+                $info = $this->getErrorPositionByOffset($text, $token['offset']);
 
                 throw new Compiler\Exception\UnexpectedToken(
-                    'Unexpected token "%s" (%s) at line %d and column %d:' .
-                    "\n" . '%s' . "\n" . str_repeat(' ', $column - 1) . '↑',
+                    'Unexpected token "%s" (%s) at line %d and column %d: ' . "\n%s\n%s",
                     0,
                     [
                         $token['value'],
                         $token['token'],
-                        $line,
-                        $column,
-                        $text
+                        $info['line'],
+                        $info['column'],
+                        $info['code'],
+                        $info['highlight']
                     ],
-                    $line,
-                    $column
+                    $info['line'],
+                    $info['column']
                 );
             }
         } while (true);


### PR DESCRIPTION
Fixes ["Incorrect calculation of line and position in utf-8 files" issue](https://github.com/hoaproject/Compiler/issues/78)

## Unrecognized token:

![image](https://user-images.githubusercontent.com/2461257/32290876-7e9b7788-bf4c-11e7-9cb3-7252b8de05db.png)

## Unexpected token:

![image](https://user-images.githubusercontent.com/2461257/32290959-b417c772-bf4c-11e7-964b-7daa71cbfcff.png)

:smile_cat: 