### PR TITLE
Fix error handling for non-UTF-8 string in Lexer

### DIFF
--- a/Exception/InternalError.php
+++ b/Exception/InternalError.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Hoa\Compiler\Exception;
+
+use LogicException;
+
+/**
+ * It probably points to some internal issue of the Hoa Compiler library.
+ * Regardless source of the bug, try to report about this exception to the library maintainers.
+ * Even if bug is yours, this exception must not happen.
+ */
+final class InternalError extends LogicException
+{
+    public function __construct($message, Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/Llk/Lexer.php
+++ b/Llk/Lexer.php
@@ -320,7 +320,7 @@ class Lexer
      */
     private function validateInputInUnicodeMode($text)
     {
-        if (strpos($this->_pcreOptions, 'u') !== false && !mb_check_encoding($text, 'utf-8')) {
+        if (strpos($this->_pcreOptions, 'u') !== false && preg_match('##u', $text) === 1) {
             throw new Compiler\Exception\Lexer(
                 'Text is not valid utf-8 string, you probably need to switch "lexer.unicode" setting off.'
             );

--- a/Llk/Lexer.php
+++ b/Llk/Lexer.php
@@ -320,7 +320,7 @@ class Lexer
      */
     private function validateInputInUnicodeMode($text)
     {
-        if (strpos($this->_pcreOptions, 'u') !== false && preg_match('##u', $text) === 1) {
+        if (strpos($this->_pcreOptions, 'u') !== false && preg_match('##u', $text) === false) {
             throw new Compiler\Exception\Lexer(
                 'Text is not valid utf-8 string, you probably need to switch "lexer.unicode" setting off.'
             );

--- a/Test/Unit/Llk/Lexer.php
+++ b/Test/Unit/Llk/Lexer.php
@@ -496,4 +496,27 @@ class Lexer extends Test\Unit\Suite
                         ' ↑'
                     );
     }
+
+    public function case_invalid_utf8_with_unicode_mode()
+    {
+        $this
+            ->given(
+                $lexer  = new SUT(['lexer.unicode' => true]),
+                $datum  = "\xFF",
+                $tokens = [
+                    'default' => [
+                        'foo' => "\xFF"
+                    ]
+                ]
+            )
+            ->when($result = $lexer->lexMe($datum, $tokens))
+            ->then
+            ->exception(function () use ($result) {
+                $result->next();
+            })
+            ->isInstanceOf(LUT\Exception\Lexer::class)
+            ->hasMessage(
+                'Text is not valid utf-8 string, you probably need to switch "lexer.unicode" setting off.'
+            );
+    }
 }


### PR DESCRIPTION
So far `Lexer` fails into infinite recursion with enabled `unicode.mode` if input data is not properly encoded.