### PR TITLE
Make nested ternary operators priority explicit

### DIFF
--- a/Bin/Pp.php
+++ b/Bin/Pp.php
@@ -231,10 +231,10 @@ class Pp extends Console\Dispatcher\Kit
                 $token['token'],
                 30 < $token['length']
                     ? mb_substr($token['value'], 0, 29) . '…'
-                    : 'EOF' === $token['token']
+                    : ('EOF' === $token['token']
                         ? str_repeat(' ', 30)
                         : $token['value'] .
-                          str_repeat(' ', 30 - $token['length']),
+                          str_repeat(' ', 30 - $token['length'])),
                 $token['offset']
             );
         }


### PR DESCRIPTION
The left-associativity of the ternary operator has been deprecated in PHP 7.4

Fixes #106